### PR TITLE
Add policy statement to s3VPCE to allow pulling from docker hub

### DIFF
--- a/lib/ethereum/lib/sync-node-stack.ts
+++ b/lib/ethereum/lib/sync-node-stack.ts
@@ -30,10 +30,10 @@ export class EthSyncNodeStack extends cdk.Stack {
         const chosenAvailabilityZone = availabilityZones.slice(0, 1)[0];
 
         // Getting our config from initialization properties
-        const {
+        const { 
             instanceType,
-            ethClientCombination,
-            instanceCpuType,
+            ethClientCombination, 
+            instanceCpuType, 
             dataVolumes,
         } = props;
 
@@ -104,7 +104,7 @@ export class EthSyncNodeStack extends cdk.Stack {
             INSTANCE_NAME: STACK_NAME,
             REGION: REGION,
         })
-
+                
         new cw.CfnDashboard(this, 'sync-cw-dashboard', {
             dashboardName: STACK_NAME,
             dashboardBody: dashboardString,

--- a/lib/ethereum/lib/sync-node-stack.ts
+++ b/lib/ethereum/lib/sync-node-stack.ts
@@ -30,10 +30,10 @@ export class EthSyncNodeStack extends cdk.Stack {
         const chosenAvailabilityZone = availabilityZones.slice(0, 1)[0];
 
         // Getting our config from initialization properties
-        const { 
+        const {
             instanceType,
-            ethClientCombination, 
-            instanceCpuType, 
+            ethClientCombination,
+            instanceCpuType,
             dataVolumes,
         } = props;
 
@@ -104,7 +104,7 @@ export class EthSyncNodeStack extends cdk.Stack {
             INSTANCE_NAME: STACK_NAME,
             REGION: REGION,
         })
-                
+
         new cw.CfnDashboard(this, 'sync-cw-dashboard', {
             dashboardName: STACK_NAME,
             dashboardBody: dashboardString,


### PR DESCRIPTION
### What does this PR do?
This PR opens the s3VPCE for `docker pull` commands, which fails otherwise. 

`docker-compose` pulls the client images from docker hub. The s3VPC needs to allow those actions. Otherwise the pulls fail with HTTP 403 and the images don't get pulled. Adding the policy statement to the VPCE fixes this and allows pulling from docker hub.

The solution is adapted from another issue: [Cannot pull images from dockerhub (403 Access Denied)](https://github.com/rancher/os/issues/2032)

### Motivation
The 'erigion-lighthouse' configuration did not work without it.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new node blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new node blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
