### PR TITLE
Clearing up and undeploying everything

### DIFF
--- a/lib/ethereum/README.md
+++ b/lib/ethereum/README.md
@@ -126,7 +126,7 @@ Note: the snapshot backup process will automatically run ever day at midnight ti
 2. Give the new RPC nodes about 30 minutes (up to 2 hours for Erigon) to initialize and then run the following query against the load balancer behind the RPC node created
 
 ```bash
-    export ETH_RPC_ABL_URL=$(cat rpc-node-deploy.json | jq -r '..|.ALBURL? | select(. != null)')
+    export ETH_RPC_ABL_URL=$(cat rpc-node-deploy.json | jq -r '..|.alburl? | select(. != null)')
     echo $ETH_RPC_ABL_URL
     
     # We query token balance of Beacon deposit contract: https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa
@@ -165,13 +165,14 @@ The result should be like this (the actual balance might change):
    # Make sure you are in aws-blockchain-node-runners/lib/ethereum
    
    # Undeploy RPC Nodes
-    cdk destroy rpc-nodes-stack
+    cdk destroy eth-rpc-nodes
 
     # Undeploy Sync Node
-    cdk destroy sync-node-stack
+    cdk destroy eth-sync-node
 
+    # You need to manually delete an s3 bucket with a name similar to 'eth-snapshots-$accountid-eth-nodes-common' on the console,firstly empty the bucket,secondly delete the bucket,and then execute
     # Delete all common components like IAM role and Security Group
-    cdk destroy common-stack
+    cdk destroy eth-common
 ```
 
 2. Follow steps to delete the Cloud9 instance in [Cloud9 Setup](../../doc/setup-cloud9.md)


### PR DESCRIPTION
### What does this PR do?

1. get the right ETH_RPC_ABL_URL value,should use 'alburl' in lowwercase
2. in 'Clearing up and undeploying everything' section, need to destroy the right stack name 

### Motivation

deploy eth node on aws graviton and cleanup

### More

- [ yes] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new node blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new node blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ yes] E2E Test successfully complete before merge?

### Additional Notes
modify lib/ethereum/README.md
