### PR TITLE
updated blocksbehind logic for bsc and .env file for base

### DIFF
--- a/lib/base/README.md
+++ b/lib/base/README.md
@@ -108,7 +108,7 @@ Base node needs a URL to a Full Ethereum Node to validate blocks it receives. Yo
 # Make sure you are in aws-blockchain-node-runners/lib/base
 cd lib/base
 pwd
-cp ./sample-configs/.env-sample-rpc .env
+cp ./sample-configs/.env-sample-full .env
 nano .env
 ```
 

--- a/lib/bsc/lib/assets/bsc-checker/syncchecker-bsc.sh
+++ b/lib/bsc/lib/assets/bsc-checker/syncchecker-bsc.sh
@@ -14,6 +14,11 @@ BSC_HIGHEST_BLOCK=$(echo $((${BSC_HIGHEST_BLOCK_HEX})))
 BSC_SYNC_BLOCK=$(echo $((${BSC_SYNC_BLOCK_HEX})))
 BSC_BLOCKS_BEHIND="$((BSC_HIGHEST_BLOCK-BSC_SYNC_BLOCK))"
 
+# Handle negative values if current block is bigger than highest block
+if [[ "$BSC_BLOCKS_BEHIND" -lt "0" ]]; then
+    BSC_BLOCKS_BEHIND=0
+fi
+
 # Sending data to CloudWatch
 TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

In the `syncchecker-bsc.sh` file, I added a check in order to be able handle negative values in the case that the current block value is bigger than the highest block value. That way, in the CW dashboard, for the **BSC Client Blocks Behind** graph, the graph doesn't keep going into the negatives. In addition to that, in the `README.md` file for Base, I fixed the name of the `.env` file. It was `cp ./sample-configs/.env-sample-rpc .env` but should be `cp ./sample-configs/.env-sample-full .env`.

### Motivation

<!-- What inspired you to submit this pull request? -->

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new node blueprints. Yes, I have added usage example to the `README.md` file in my blueprint folder
- [ ] Mandatory for new node blueprints. Yes, I have implemented automated tests for all stacks in my blueprint and they pass
- [ ] Mandatory for new node blueprints. Yes, I have added a reference to my `README.md` file to `website/docs` section for this feature
- [ ] Yes, I have set up and ran all [pre-merge quality control tools](./docs/pre-merge-tools.md) on my local machine and they don't show warnings.

### For Moderators

- [ ] The tests for all current blueprints successfully complete before merge?
- [ ] Mandatory for new node blueprints. All [pre-merge quality control tools](./docs/pre-merge-tools.md) and `cdk-nag` tools don't show warnings?
- [ ] Mandatory for new node blueprints. The deployment test works on blank AWS account according to instructions in the `README.md` before merge?
- [ ] Mandatory for new node blueprints. The website builds without errors?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
