### PR TITLE
BSC Moved CloudWatch configuration closer to the end of the user-data…

### DIFF
--- a/lib/bsc/lib/assets/user-data/node.sh
+++ b/lib/bsc/lib/assets/user-data/node.sh
@@ -49,14 +49,6 @@ echo "Downloading assets zip file"
 aws s3 cp $ASSETS_S3_PATH ./assets.zip --region $AWS_REGION
 unzip -q assets.zip
 
-echo 'Configuring CloudWatch Agent'
-cp /opt/cw-agent.json /opt/aws/amazon-cloudwatch-agent/etc/custom-amazon-cloudwatch-agent.json
-
-echo "Starting CloudWatch Agent"
-/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
--a fetch-config -c file:/opt/aws/amazon-cloudwatch-agent/etc/custom-amazon-cloudwatch-agent.json -m ec2 -s
-systemctl status amazon-cloudwatch-agent
-
 aws configure set default.s3.max_concurrent_requests 50
 aws configure set default.s3.multipart_chunksize 256MB
 
@@ -198,6 +190,14 @@ if [[ "$BSC_DOWNLOAD_SNAPSHOT" == "true"  ]]; then
 fi
 
 chown bcuser:bcuser -R /data
+
+echo 'Configuring CloudWatch Agent'
+cp /opt/cw-agent.json /opt/aws/amazon-cloudwatch-agent/etc/custom-amazon-cloudwatch-agent.json
+
+echo "Starting CloudWatch Agent"
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+-a fetch-config -c file:/opt/aws/amazon-cloudwatch-agent/etc/custom-amazon-cloudwatch-agent.json -m ec2 -s
+systemctl status amazon-cloudwatch-agent
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now bsc


### PR DESCRIPTION
… script

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new node blueprints. Yes, I have added usage example to the `README.md` file in my blueprint folder
- [ ] Mandatory for new node blueprints. Yes, I have implemented automated tests for all stacks in my blueprint and they pass
- [ ] Mandatory for new node blueprints. Yes, I have added a reference to my `README.md` file to `website/docs` section for this feature
- [ ] Yes, I have set up and ran all [pre-merge quality control tools](./docs/pre-merge-tools.md) on my local machine and they don't show warnings.

### For Moderators

- [ ] The tests for all current blueprints successfully complete before merge?
- [ ] Mandatory for new node blueprints. All [pre-merge quality control tools](./docs/pre-merge-tools.md) and `cdk-nag` tools don't show warnings?
- [ ] Mandatory for new node blueprints. The deployment test works on blank AWS account according to instructions in the `README.md` before merge?
- [ ] Mandatory for new node blueprints. The website builds without errors?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
