### PR TITLE
Fix download link extraction

### DIFF
--- a/lib/bsc/lib/assets/download-snapshot.sh
+++ b/lib/bsc/lib/assets/download-snapshot.sh
@@ -12,7 +12,7 @@ BSC_SNAPSHOTS_DIR=/data/
 BSC_SNAPSHOTS_DOWNLOAD_STATUS=-1
 
 if [ "$BSC_SNAPSHOTS_URI" == "none" ]; then
-  BSC_SNAPSHOTS_URI=$(curl https://raw.githubusercontent.com/48Club/bsc-snapshots/main/data.json | jq -r .hash.local.link)
+  BSC_SNAPSHOTS_URI=$(curl https://raw.githubusercontent.com/48Club/bsc-snapshots/main/data.json | jq -r .geth.local.link)
 fi
 
 # take about 1 hour to download the bsc snapshot


### PR DESCRIPTION
### What does this PR do?

Fix for #134

It fixes the extraction of the download link for a BSC snapshot 