### PR TITLE
ci: migrate website deploy to first-party GitHub Pages actions

### DIFF
--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -7,12 +7,22 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+# Least-privilege: read the repo, deploy to Pages via OIDC. No contents: write.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent Pages deploy; never cancel an in-progress production
+# publish (cancel-in-progress: false).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
+    name: Build Docusaurus site
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     defaults:
       run:
         shell: bash
@@ -26,23 +36,23 @@ jobs:
           cache-dependency-path: website/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
       - name: Build website
         run: npm run build
-
-      # Popular action to deploy to GitHub Pages:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./website/build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: github-actions[bot]@users.noreply.github.com
+          path: website/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.kiro/steering/ci-workflows.md
+++ b/.kiro/steering/ci-workflows.md
@@ -22,8 +22,10 @@ review churn:
   `tj-actions/changed-files` compromise, CVE-2025-30066) target third-party
   actions. There are only a handful in this repo, so the cost is small.
   Especially mandatory for any third-party action that runs with a `write`
-  permission scope or receives a token (e.g. `peaceiris/actions-gh-pages` in
-  `website-deploy.yaml`, which has `contents: write`).
+  permission scope or receives a token. (The website deploy previously used
+  `peaceiris/actions-gh-pages` with `contents: write`; it now uses GitHub's
+  first-party Pages actions with OIDC, so no third-party action holds repository
+  write access.)
 - **First-party actions (`actions/*`, `github/*`): a major-version tag (e.g.
   `@v4`) is acceptable.** These are GitHub-owned and carry a much lower
   tag-repointing risk. Allowing major tags here removes most Dependabot review

--- a/.kiro/steering/git-workflow.md
+++ b/.kiro/steering/git-workflow.md
@@ -28,7 +28,7 @@ Trunk-based development around a single integration branch.
 |--------|------|-------|
 | `main` | Default + integration branch. Always releasable. | Protected. No force-push, no deletion. Website auto-deploys from it. |
 | `v1` | Frozen legacy (pre-rewrite). | Protected. No new features. Security-only fixes if ever. Linked from `CHANGELOG.md`. |
-| `gh-pages` | Machine-managed Docusaurus build output. | Never hand-edit; written by `website-deploy.yaml`. |
+| `gh-pages` | **Legacy** Docusaurus deploy branch (pre-first-party-Pages). | No longer written — the site now deploys via the first-party Pages artifact model in `website-deploy.yaml`. Delete once the first-party deploy is verified. |
 | `feat/*`, `fix/*`, `docs/*`, `chore/*`, `ci/*` | Short-lived working branches for non-trivial work. | Branch from `main`, open a PR, delete after merge. |
 | `dependabot/*` | Automated dependency PRs. | Managed by Dependabot; merge or close, don't push to them. |
 
@@ -187,9 +187,10 @@ supply chain stays protected:
   second maintainer joins, raise to 1 and add a `CODEOWNERS` file.
 - **Require linear history** — pairs with squash-merge.
 - **Signed commits:** recommended if commit signing is set up (SSH/GPG/gitsign).
-  This rule applies per-branch, so enabling it on `main` does not affect the
-  `gh-pages` deploy (a separate branch). Dependabot's commits are signed by
-  GitHub. Optional while solo; enable once your own signing is configured.
+  The first-party Pages deploy publishes an artifact rather than pushing commits,
+  so a signed-commits rule on `main` won't interfere with the website deploy.
+  Dependabot's commits are signed by GitHub. Optional while solo; enable once
+  your own signing is configured.
 
 Revisit these when the contributor base grows: require approvals, add
 `CODEOWNERS`, and consider promoting ASH to a blocking check.

--- a/website/README.md
+++ b/website/README.md
@@ -26,8 +26,12 @@ This command generates static content into the `build` directory and can be serv
 
 ### Deployment
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
+Deployment is automated. On every push to `main`, the
+[`website-deploy.yaml`](../.github/workflows/website-deploy.yaml) GitHub Actions
+workflow builds the site and publishes it to GitHub Pages using GitHub's
+first-party Pages actions (build → `upload-pages-artifact` → `deploy-pages` to
+the `github-pages` environment). There is no manual deploy step and no push to a
+`gh-pages` branch.
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+The Docusaurus `yarn deploy` / `npm run deploy` command (which would build and
+push to a `gh-pages` branch) is **not** used by this repository.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -24,7 +24,6 @@ const config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'aws-samples', // Usually your GitHub org/user name.
   projectName: 'aws-blockchain-node-runners', // Usually your repo name.
-  deploymentBranch: 'gh-pages',
   githubHost: 'github.com',
 
   markdown: {


### PR DESCRIPTION
Replace the third-party peaceiris/actions-gh-pages publish step with GitHub's first-party Pages actions (configure-pages, upload-pages-artifact, deploy-pages) in a two-job build/deploy workflow. Drop contents: write in favor of the least-privilege OIDC model (contents: read, pages: write, id-token: write) and add a pages concurrency group with cancel-in-progress: false.

Remove the now-unused deploymentBranch from docusaurus.config.js, and update website/README.md plus the git-workflow and ci-workflows steering docs to describe the artifact-based deploy (no gh-pages branch push).

Requires a one-time repo setting change: Settings -> Pages -> Build and deployment -> Source = "GitHub Actions".

Refs: .kiro/specs/github-pages-firstparty-deploy

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [x] I have run `npm run build` successfully
- [x] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [x] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
