### PR TITLE
ci(website): move Pages deploy to Node 24 actions and runtime

### DIFF
--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -31,17 +31,17 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: website/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Build website
         run: npm run build
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/website-test-deploy.yml
+++ b/.github/workflows/website-test-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: website/package-lock.json
 


### PR DESCRIPTION
The first-party Pages deploy failed ("Deployment failed, try again later") and warned that configure-pages@v5 / upload-artifact@v4 target the deprecated Node 20 and were force-run on Node 24. Move the website workflows off Node 20:

- actions/configure-pages v5 -> v6
- actions/upload-pages-artifact v3 -> v5
- actions/deploy-pages v4 -> v5
- setup-node node-version 20 -> 24 in both website-deploy.yaml and website-test-deploy.yml

Node 24 is the current active LTS and the version the site build was verified on locally. This clears the Node 20 deprecation warning and moves deploy-pages onto a Node 24-compatible release. A lingering "try again later" is a transient/wedged Pages deploy and clears on a workflow re-run.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
