### PR TITLE
chore(deps): upgrade TypeScript to 6.0 and ts-jest to 29.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
         "aws-cdk": "^2.1033.0",
         "cdk-nag": "^2.37.55",
         "jest": "^30.2.0",
-        "ts-jest": "^29.4.6",
+        "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
-        "typescript": "~5.9.3"
+        "typescript": "~6.0.3"
       }
     },
     "blueprints/base": {
@@ -4740,19 +4740,19 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -4769,7 +4769,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -4793,9 +4793,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4895,9 +4895,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "aws-cdk": "^2.1033.0",
     "cdk-nag": "^2.37.55",
     "jest": "^30.2.0",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
-    "typescript": "~5.9.3"
+    "typescript": "~6.0.3"
   },
   "dependencies": {
     "aws-bnr-blueprint-dummy": "file:blueprints/dummy",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
     "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
+    // TS 6 deprecates moduleResolution "node" (node10); acknowledge it here
+    // until it is modernized (e.g. to "node16"/"bundler") before TS 7.
+    "ignoreDeprecations": "6.0",
     "lib": [
       "es2020"
     ],


### PR DESCRIPTION
Bump typescript ~5.9.3 -> ~6.0.3. ts-jest 29.4.6 caps its typescript peer at "<6", so also bump ts-jest to ^29.4.11 (peer ">=4.3 <7"); ts-node 10.9.2 already supports TS 6.

TS 6 reports moduleResolution "node" (node10) as deprecated (removed in TS 7). Add "ignoreDeprecations": "6.0" to tsconfig.json as the sanctioned bridge until moduleResolution is modernized (e.g. to node16/bundler) before TS 7.

Verified: tsc build, jest (473 tests across 22 suites), and cdk synth all pass.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
