### PR TITLE
chore: group CDK deps in Dependabot; stop duplicating versions in tech.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,18 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      # Keep the CDK CLI and library (plus constructs) in a single PR: they are
+      # version-coupled — aws-cdk-lib's cloud-assembly schema must be readable
+      # by the aws-cdk CLI. NOTE: grouping only batches *version* updates. A
+      # security advisory affecting just one of them can still bump it alone
+      # (Dependabot only touches packages with an update/advisory), so the
+      # "Validate CDK synthesis" CI check remains the real guard against
+      # lib/CLI schema drift.
+      aws-cdk:
+        patterns:
+          - "aws-cdk"
+          - "aws-cdk-lib"
+          - "constructs"
       npm:
         patterns:
           - "*"

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -36,10 +36,30 @@ npx cdk destroy
 ```
 
 ## Dependencies
-- **aws-cdk-lib**: ^2.189.1 - Core CDK library
-- **constructs**: ^10.3.0 - CDK constructs framework
-- **dotenv**: ^16.4.5 - Environment variable management
-- **cdk-nag**: ^2.36.18 - Security and compliance validation
+
+The root `package.json` (and `package-lock.json`) is the source of truth for
+versions; the list below is a summary and may lag. Update it when the core
+dependencies change.
+
+Runtime dependencies:
+- **aws-cdk-lib**: ^2.261.0 - Core CDK v2 library
+- **constructs**: ^10.4.3 - CDK constructs framework
+- **dotenv**: ^17.2.3 - Environment variable management
+- **source-map-support**: ^0.5.21 - Source maps for stack traces
+
+Build / test toolchain (devDependencies):
+- **aws-cdk** (CLI): ^2.1129.0 - CDK CLI for synth/deploy
+- **typescript**: ~6.0.3 - TypeScript compiler
+- **ts-node**: ^10.9.2 - TypeScript execution for the CDK app entrypoint
+- **cdk-nag**: ^2.37.55 - Security and compliance validation
+- **jest**: ^30.2.0 / **ts-jest**: ^29.4.11 - Unit testing
+- **@types/node**: ^24.10.1 / **@types/jest**: ^30.0.0 - Type definitions
+
+> The `aws-cdk` CLI and `aws-cdk-lib` are version-coupled: the CLI must be new
+> enough to read the cloud-assembly schema emitted by the library. Bump them
+> together (the "Validate CDK synthesis" CI check enforces this). Keep
+> `@types/node`'s major aligned with the Node.js runtime you target rather than
+> chasing its latest release.
 
 ## Development Standards
 - Strict TypeScript configuration with null checks

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -37,26 +37,28 @@ npx cdk destroy
 
 ## Dependencies
 
-The root `package.json` (and `package-lock.json`) is the source of truth for
-versions; the list below is a summary and may lag. Update it when the core
-dependencies change.
+Versions are intentionally **not** listed here — they are tracked in the package
+manifests, which are the single source of truth. See the root `package.json` and
+`package-lock.json` (CDK app) and `website/package.json` (docs site) for the
+current, authoritative versions. This section only names the key dependencies and
+their roles.
 
-Runtime dependencies:
-- **aws-cdk-lib**: ^2.261.0 - Core CDK v2 library
-- **constructs**: ^10.4.3 - CDK constructs framework
-- **dotenv**: ^17.2.3 - Environment variable management
-- **source-map-support**: ^0.5.21 - Source maps for stack traces
+Runtime dependencies (CDK app):
+- **aws-cdk-lib** - Core CDK v2 library
+- **constructs** - CDK constructs framework
+- **dotenv** - Environment variable management
+- **source-map-support** - Source maps for stack traces
 
 Build / test toolchain (devDependencies):
-- **aws-cdk** (CLI): ^2.1129.0 - CDK CLI for synth/deploy
-- **typescript**: ~6.0.3 - TypeScript compiler
-- **ts-node**: ^10.9.2 - TypeScript execution for the CDK app entrypoint
-- **cdk-nag**: ^2.37.55 - Security and compliance validation
-- **jest**: ^30.2.0 / **ts-jest**: ^29.4.11 - Unit testing
-- **@types/node**: ^24.10.1 / **@types/jest**: ^30.0.0 - Type definitions
+- **aws-cdk** (CLI) - CDK CLI for synth/deploy
+- **typescript** - TypeScript compiler
+- **ts-node** - TypeScript execution for the CDK app entrypoint
+- **cdk-nag** - Security and compliance validation
+- **jest** / **ts-jest** - Unit testing
+- **@types/node** / **@types/jest** - Type definitions
 
 > The `aws-cdk` CLI and `aws-cdk-lib` are version-coupled: the CLI must be new
-> enough to read the cloud-assembly schema emitted by the library. Bump them
+> enough to read the cloud-assembly schema emitted by the library, so bump them
 > together (the "Validate CDK synthesis" CI check enforces this). Keep
 > `@types/node`'s major aligned with the Node.js runtime you target rather than
 > chasing its latest release.


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
