### PR TITLE
ci: hold cdk-nag and @types/node major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,19 @@ updates:
     labels:
       - dependencies
       - npm
+    ignore:
+      # Hold cdk-nag on v2.x: v3 is a breaking rewrite (IAspect ->
+      # IPolicyValidationPlugin, and NagSuppressions -> per-finding
+      # Validations.acknowledge). Deferred until upstream supports prefix/bulk
+      # acknowledgment. Minor/patch (2.x) updates still flow; unignore when
+      # ready to do the v3 migration.
+      - dependency-name: "cdk-nag"
+        update-types: ["version-update:semver-major"]
+      # Keep @types/node aligned with the Node.js runtime major we target
+      # (currently 24); bump it deliberately when the runtime moves rather than
+      # chasing the newest typings. Minor/patch within the major still flow.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     # The blueprints are local file: deps (file:blueprints/*); Dependabot
     # ignores those automatically. Blockchain client versions are managed
     # separately via the @version-update workflow, not here.


### PR DESCRIPTION
Add ignore rules to the root npm ecosystem so Dependabot stops proposing major version bumps for two dependencies (minor/patch updates still flow):

- cdk-nag: v3 is a breaking rewrite (IAspect -> IPolicyValidationPlugin, and NagSuppressions -> per-finding Validations.acknowledge). Deferred until upstream supports prefix/bulk acknowledgment. This is why the grouped npm PR #275 fails "Validate CDK synthesis" — the ignore drops the v3 bump so a regenerated PR builds. Unignore when ready to do the v3 migration.
- @types/node: keep aligned with the Node.js runtime major we target (currently 24) rather than chasing the newest typings.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
