### PR TITLE
Docs/external blueprint install peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Blockchain protocols are delivered as NPM packages (blueprints). Six built-in bl
 
 ```bash
 # Install an external blueprint
-npm install aws-bnr-blueprint-polygon
+npm install aws-bnr-blueprint-polygon --legacy-peer-deps
 
 # Or from GitHub
-npm install github:owner/aws-bnr-blueprint-polygon#v1.0.0
+npm install github:owner/aws-bnr-blueprint-polygon#v1.0.0 --legacy-peer-deps
 ```
 
-After `npm install`, set `BLOCKCHAIN_PROTOCOL` in your `.env` to the protocol name and deploy. See [Adding New Protocols](./docs/ageai-add-protocol-prompt.md) for how to create your own blueprint package.
+The `--legacy-peer-deps` flag is required: blueprints declare a peer dependency on the `aws-blockchain-node-runners` framework, which is not published to the npm registry, so npm's default (strict) peer resolution would otherwise fail.
+
+After installing, set `BLOCKCHAIN_PROTOCOL` in your `.env` to the protocol name and deploy. See [Adding New Protocols](./docs/ageai-add-protocol-prompt.md) for how to create your own blueprint package.
 
 ## Prerequisites
 

--- a/docs/ageai-add-protocol-prompt.md
+++ b/docs/ageai-add-protocol-prompt.md
@@ -366,9 +366,9 @@ For Path B (external blueprints), test the package against a local checkout of N
    git clone https://github.com/aws-samples/aws-blockchain-node-runners.git
    cd aws-blockchain-node-runners
    npm install
-   npm install /path/to/your/blueprint
+   npm install /path/to/your/blueprint --legacy-peer-deps
    ```
-   Pointing `npm install` at the local blueprint directory links it into `node_modules/` so the `ConfigurationLoader` resolves it like any published blueprint.
+   Pointing `npm install` at the local blueprint directory links it into `node_modules/` so the `ConfigurationLoader` resolves it like any published blueprint. The `--legacy-peer-deps` flag is required because the blueprint declares a peer dependency on the `aws-blockchain-node-runners` framework, which is not published to the npm registry.
 
 2. **Synthesize the stack** to validate configuration files and user-data scripts resolve:
    ```bash
@@ -465,8 +465,9 @@ DO NOT:
 
 Once an external blueprint (Path B) is tested, distribute it so users can install it into their own Node Runners checkout. Choose one or more of the following:
 
-- **NPM Registry**: Publish the package with `npm publish`. Users then install it with `npm install aws-bnr-blueprint-<protocol>`.
-- **GitHub**: Push the blueprint to a public repository. Users can install directly from the repo with `npm install github:org/repo`.
+- **NPM Registry**: Publish the package with `npm publish`. Users then install it with `npm install aws-bnr-blueprint-<protocol> --legacy-peer-deps`.
+- **GitHub**: Push the blueprint to a public repository. Users can install directly from the repo with `npm install github:org/repo --legacy-peer-deps`.
+- **Note**: The `--legacy-peer-deps` flag is required when installing an external blueprint because blueprints declare a peer dependency on the `aws-blockchain-node-runners` framework, which is not published to the npm registry (npm 7+ strict peer resolution would otherwise fail).
 - **Community Catalog**: Open a pull request to add an entry for your blueprint to the Community Blueprints Catalog page so others can discover it.
 
 After installation by any method, the blueprint lands in `node_modules/` and the `ConfigurationLoader` resolves it identically to a built-in blueprint — users deploy it with `BLOCKCHAIN_PROTOCOL=<protocol> npx cdk deploy`.

--- a/docs/ageai-blueprint-security-review.md
+++ b/docs/ageai-blueprint-security-review.md
@@ -24,7 +24,7 @@ External blueprints (installed by user):
 If the user asks to discover community blueprints:
 1. Run: `npm search aws-bnr-blueprint`
 2. Present results with package name, description, and version
-3. Show the install command for any blueprint they want to add: `npm install aws-bnr-blueprint-<protocol>`
+3. Show the install command for any blueprint they want to add: `npm install aws-bnr-blueprint-<protocol> --legacy-peer-deps` (the `--legacy-peer-deps` flag is required because blueprints declare a peer dependency on the `aws-blockchain-node-runners` framework, which is not published to the npm registry)
 
 Present this disclaimer: Community blueprints are NOT reviewed or verified by the core repository maintainers. The user assumes full responsibility for any external blueprint they install and deploy. Always perform a security review before deploying an external blueprint.
 

--- a/website/docs/blueprints/community.mdx
+++ b/website/docs/blueprints/community.mdx
@@ -20,7 +20,7 @@ Community blueprints will be listed here as they are published and submitted for
 
 | Protocol | Package | Maintainer | Docs | Networks | Install |
 |----------|---------|------------|------|----------|---------|
-| _Example Chain_ | `aws-bnr-blueprint-example-chain` | [@example-org](https://github.com/example-org) | [README](https://github.com/example-org/aws-bnr-blueprint-example-chain#readme) | Mainnet, Testnet | `npm install aws-bnr-blueprint-example-chain` |
+| _Example Chain_ | `aws-bnr-blueprint-example-chain` | [@example-org](https://github.com/example-org) | [README](https://github.com/example-org/aws-bnr-blueprint-example-chain#readme) | Mainnet, Testnet | `npm install aws-bnr-blueprint-example-chain --legacy-peer-deps` |
 
 *The example above shows the format. Real entries will appear once community blueprints are submitted.*
 
@@ -31,14 +31,20 @@ Community blueprints will be listed here as they are published and submitted for
 1. **Install the package:**
 
    ```bash
-   npm install aws-bnr-blueprint-<protocol>
+   npm install aws-bnr-blueprint-<protocol> --legacy-peer-deps
    ```
 
    Or from a GitHub repository:
 
    ```bash
-   npm install github:org/aws-bnr-blueprint-<protocol>
+   npm install github:org/aws-bnr-blueprint-<protocol> --legacy-peer-deps
    ```
+
+   :::note Why `--legacy-peer-deps`?
+
+   Blueprints declare a peer dependency on the `aws-blockchain-node-runners` framework, which is not published to the npm registry. Without this flag, npm's strict peer resolution (npm 7+) fails with a `404 Not Found` for `aws-blockchain-node-runners`.
+
+   :::
 
 2. **Configure your `.env` file** using the blueprint's sample configs (check the blueprint's README for available networks and options).
 

--- a/website/docs/blueprints/community.mdx
+++ b/website/docs/blueprints/community.mdx
@@ -8,21 +8,21 @@ title: Community Blueprints
 
 Community blueprints are **externally maintained** Node Runners blueprints created by the community. They follow the same architecture as built-in blueprints but are published and maintained independently.
 
-:::info No community blueprints published yet
+:::info First community blueprint available
 
-The community blueprint system is new. Be the first to publish one! See [Creating Your Own Blueprint](#creating-your-own-blueprint) below.
+The community blueprint system is new. **TRON** is the first published community blueprint — see the [Catalog](#catalog) below. Want to add another? See [Creating Your Own Blueprint](#creating-your-own-blueprint).
 
 :::
 
 ## Catalog
 
-Community blueprints will be listed here as they are published and submitted for inclusion.
+Community blueprints are listed here as they are published and submitted for inclusion.
 
 | Protocol | Package | Maintainer | Docs | Networks | Install |
 |----------|---------|------------|------|----------|---------|
-| _Example Chain_ | `aws-bnr-blueprint-example-chain` | [@example-org](https://github.com/example-org) | [README](https://github.com/example-org/aws-bnr-blueprint-example-chain#readme) | Mainnet, Testnet | `npm install aws-bnr-blueprint-example-chain --legacy-peer-deps` |
+| TRON | `aws-bnr-blueprint-tron` | [@Tristenyang](https://github.com/Tristenyang) | [README](https://github.com/Tristenyang/aws-bnr-blueprint-tron#readme) | Mainnet, Nile | `npm install github:Tristenyang/aws-bnr-blueprint-tron --legacy-peer-deps` |
 
-*The example above shows the format. Real entries will appear once community blueprints are submitted.*
+TRON deploys an RPC node using the [java-tron](https://github.com/tronprotocol/java-tron) client, supporting both FullNode and Lite FullNode variants on x86_64 and ARM64/Graviton, in single-node and HA modes. *More community blueprints will appear here as they are submitted.*
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [x] I have updated relevant documentation (if applicable)
- [x] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
