### PR TITLE
fix(ci): Correct harden-runner SHA pin in stale workflow

### DIFF
--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@cb605e52c26070c328afc4141f4ae0c868cc51a9 # v2.10.4
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
 


### PR DESCRIPTION
The Harden Runner step pinned step-security/harden-runner to a SHA whose tail was mangled, so GitHub Actions could not resolve the action and the 'Stale issue & PR handler' workflow failed at setup. Repin to the real commit SHA for the v2.10.4 tag it was labeled as.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
