### PR TITLE
ci: block PRs on ASH prompt-injection findings in prompt files

### DIFF
--- a/.github/workflows/ash-security-scan.yml
+++ b/.github/workflows/ash-security-scan.yml
@@ -103,6 +103,12 @@ jobs:
               options:
                 include_detailed_findings: true
                 max_detailed_findings: 100
+            # flat-json is ASH's native machine-readable report. The
+            # prompt-injection gate below parses it (reports/ash.flat.json) to
+            # decide, per rule ID, whether to block. Enabling reporters here
+            # overrides ASH's defaults, so it must be listed explicitly.
+            flat-json:
+              enabled: true
           scanners:
             semgrep:
               enabled: true
@@ -116,11 +122,13 @@ jobs:
                   - '.ash/semgrep-rules/prompt-injection.yml'
           EOF
           ash --mode container --config .ash_config.yaml 2>&1 | tee /tmp/ash-output.log
-        # Intentionally non-blocking: findings are surfaced as a PR comment by the
-        # companion "ASH Security Scan - Post Comments" workflow rather than failing
-        # CI. This keeps community/fork PRs reviewable while still flagging issues.
-        # If you want findings to block merges, gate on the `has_findings` output
-        # of the next step (e.g. add a step that exits 1 when has_findings == true).
+        # Kept non-blocking on purpose: a raw ASH exit code can't tell "found a
+        # finding" from "the scanner crashed". All findings are surfaced as a PR
+        # comment by the companion "ASH Security Scan - Post Comments" workflow.
+        # The explicit "Prompt-injection gate" step below makes the only blocking
+        # decision — narrowly, on the four ERROR-severity prompt-injection rules —
+        # by parsing the flat-json report, so infra flakiness never masquerades as
+        # a clean pass.
         continue-on-error: true
 
       - name: Process scan results
@@ -178,6 +186,83 @@ jobs:
             /tmp/pr_number.txt
             /tmp/pr_sha.txt
           retention-days: 7
+
+      # Narrow blocking gate. Runs AFTER the artifact upload so the companion
+      # comment workflow still receives its input even when this step fails the
+      # job. Only the four ERROR-severity prompt-injection rules block; the
+      # WARNING jailbreak rule and every other ASH finding stay advisory
+      # (surfaced in the PR comment). The gate can only ever fire on PRs that
+      # modify AI prompt files (docs/ageai-*.md, .kiro/prompts/*.md) — the same
+      # paths the custom rules are scoped to — so it has near-zero blast radius
+      # for unrelated contributions.
+      - name: Prompt-injection gate
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          set -euo pipefail
+
+          # The four ERROR-severity rule IDs from
+          # .github/semgrep/prompt-injection.yml. The fifth rule
+          # (prompt-injection-jailbreak-or-safety-bypass, WARNING) is
+          # intentionally excluded — it is the fuzziest matcher and stays
+          # advisory-only.
+          BLOCKING_RULES='prompt-injection-instruction-override|prompt-injection-reveal-system-prompt|prompt-injection-hide-from-user|prompt-injection-secret-exfiltration'
+
+          # Did this PR touch any in-scope AI prompt file? Mirror the rules'
+          # paths.include globs. The gate only engages when it did.
+          PROMPT_FILES_CHANGED=false
+          for f in $ALL_CHANGED_FILES; do
+            case "$f" in
+              docs/ageai-*.md|.kiro/prompts/*.md) PROMPT_FILES_CHANGED=true ;;
+            esac
+          done
+
+          if [ "$PROMPT_FILES_CHANGED" != "true" ]; then
+            echo "No AI prompt files changed — prompt-injection gate not applicable."
+            exit 0
+          fi
+
+          echo "AI prompt file(s) changed — enforcing prompt-injection gate."
+
+          # ASH writes its native machine-readable report here. Locate it rather
+          # than hard-coding the full path so a minor ASH layout change doesn't
+          # silently break the gate.
+          FLAT_JSON=$(find /tmp/ash-scan -type f -name 'ash.flat.json' 2>/dev/null | head -1 || true)
+
+          # Distinguish "scan failed to run" from "scan found nothing". A PR that
+          # edits a prompt file MUST have a parseable report; if it doesn't, the
+          # scan didn't actually vet the prompt — fail closed instead of treating
+          # a non-existent result as a clean pass.
+          if [ -z "$FLAT_JSON" ] || [ ! -s "$FLAT_JSON" ] || ! jq -e . "$FLAT_JSON" >/dev/null 2>&1; then
+            echo "::error::ASH produced no parseable results for a PR that modified AI prompt files. This is a scan-failed-to-run state, not a clean pass. Re-run the scan; if it keeps failing, investigate before merging."
+            exit 1
+          fi
+
+          # Count non-suppressed findings from the blocking rule IDs. Matching on
+          # both rule_id and title guards against scanner-specific id namespacing.
+          # is_suppressed == true means an inline `nosemgrep: <rule-id>` accepted
+          # the finding — those do not block (the auditable escape hatch).
+          HITS=$(jq --arg re "$BLOCKING_RULES" '
+            [ .findings[]
+              | select(.is_suppressed != true)
+              | select(((.rule_id // "") | test($re)) or ((.title // "") | test($re)))
+            ] | length
+          ' "$FLAT_JSON")
+
+          if [ "${HITS:-0}" -gt 0 ]; then
+            echo "::error::Prompt-injection finding(s) detected in an AI prompt file (${HITS} blocking). Review the flagged content. If it is a legitimate false positive, add an inline 'nosemgrep: <rule-id>' comment with justification on the offending line."
+            echo "Blocking findings:"
+            jq -r --arg re "$BLOCKING_RULES" '
+              .findings[]
+              | select(.is_suppressed != true)
+              | select(((.rule_id // "") | test($re)) or ((.title // "") | test($re)))
+              | "  - \(.rule_id // .title) @ \(.file_path // "?"):\(.line_start // "?")"
+            ' "$FLAT_JSON"
+            exit 1
+          fi
+
+          echo "✅ No blocking prompt-injection findings in changed prompt files."
 
       - name: Skip message
         if: steps.changed-files.outputs.any_changed == 'false'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 Your PR will be checked by automated CI workflows including security scanning (ASH), CodeQL analysis, dependency review, and ShellCheck for shell scripts. Address any findings before requesting review.
 
+Most ASH findings are advisory (reported as a PR comment). The exception: prompt-injection findings on AI prompt files (`docs/ageai-*.md`, `.kiro/prompts/*.md`) are **blocking** — the scan fails and the PR cannot merge until resolved. If a match is a genuine false positive (for example, security-review wording that legitimately describes an attack pattern), suppress it with an inline `nosemgrep: <rule-id>` comment on the offending line and a short justification. Suppressions are version-controlled and reviewed in the diff.
+
 
 ## Branching, Commits, and Releases
 


### PR DESCRIPTION
Promote the custom prompt-injection Semgrep rules from advisory to a narrow blocking gate after a clean ~19-day burn-in (0 findings, 0 false positives). Enable ASH's flat-json reporter and add a gate step that parses reports/ash.flat.json.

The gate only engages when a PR changes an in-scope AI prompt file (docs/ageai-*.md, .kiro/prompts/*.md), so unrelated PRs are unaffected. It blocks only on the four ERROR-severity rule IDs; the WARNING jailbreak rule and all other ASH findings stay advisory (PR comment). It fails closed when a prompt file changed but no parseable report exists (scan-did-not-run is not a clean pass), and honors inline 'nosemgrep: <rule-id>' suppressions via the finding is_suppressed flag.

The gate runs after the artifact upload so the companion comment workflow still posts, and the ASH run step stays continue-on-error so scanner crashes never masquerade as a clean pass. Documented the blocking behavior and the suppression escape hatch in CONTRIBUTING.md.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
