### PR TITLE
docs(traffic-shaping): Correct monthly transfer estimates

### DIFF
--- a/docs/traffic-shaping.md
+++ b/docs/traffic-shaping.md
@@ -20,9 +20,11 @@ The system operates in a continuous cycle: when a node is fully synchronized (bl
 
 ## Examples of traffic limits
 
-- **20 Mbit/s limit**: ~0.2 TiB/month
-- **40 Mbit/s limit**: ~0.4 TiB/month
-- **100 Mbit/s limit**: ~1 TiB/month
+Assuming a sustained transfer at the configured cap over an average month (~730 hours), the maximum outbound volume is roughly **0.3 TiB per Mbit/s** (`Mbit/s × 10⁶ ÷ 8 bytes/s × 2,628,000 s ÷ 2⁴⁰`):
+
+- **20 Mbit/s limit**: up to 6 TiB/month
+- **40 Mbit/s limit**: up to 12 TiB/month
+- **100 Mbit/s limit**: up to 30 TiB/month
 
 ## When to Use Traffic Shaping
 


### PR DESCRIPTION
The "Examples of traffic limits" section mapped each bandwidth cap to a monthly volume using TiB/month = Mbit/s / 100, which has no physical basis (the values were low by roughly 30x).

Recalculate using sustained-transfer math (~0.3 TiB/month per Mbit/s over an average 730-hour month) and add the formula inline so the numbers are reproducible. Values are framed as "up to" to reflect that they are ceilings assuming the cap is saturated continuously.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [x] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
