### PR TITLE
feat(ethereum): upgrade Reth archive to 2.3.0 + Lighthouse 8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - **Ethereum**: bumped client versions — Geth `1.17.3` → `1.17.4`, Erigon `3.4.3` → `3.5.0`, Nethermind `1.38.1` → `1.39.0`, Prysm `7.1.5` → `7.1.6`, Teku `26.6.1` → `26.7.0`. Configuration file names and matching `samples/` were updated accordingly.
+- **Ethereum**: upgraded the Reth archive configuration to Reth `1.10.2` → `2.3.0` and Lighthouse `8.1.3` → `8.2.0` (`reth-2.3.0-lighthouse-8.2.0-archive.yml`). Reth 2.x makes **Storage V2** the default; there is no in-place upgrade for an existing Reth v1 datadir, so upgrading requires deploying a new node and resyncing (consistent with the blueprint's replace-the-instance upgrade model). Reth 2.2 also enables Discv5 discovery by default. No blueprint CLI flags changed.
 - **Solana**: Agave `4.1.0-rc.1` → `4.1.1` (release candidate replaced with the stable release on the same line); Frankendancer `0.912.40003` → `0.1005.40100`.
 - **BNB Chain**: BSC Reth `v0.0.10-beta` → `v0.1.0-fix`.
 - **Bitcoin**: Bitcoin Core `v31.0` → `v31.1`.

--- a/blueprints/ethereum/configurations/reth-2.3.0-lighthouse-8.2.0-archive.yml
+++ b/blueprints/ethereum/configurations/reth-2.3.0-lighthouse-8.2.0-archive.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
     execution:
-        image: ghcr.io/paradigmxyz/reth:v1.10.2
+        image: ghcr.io/paradigmxyz/reth:v2.3.0
         container_name: execution
         restart: always
         pid: host
@@ -34,7 +34,7 @@ services:
         network_mode: host
 
     consensus:
-        image: sigp/lighthouse:v8.1.3
+        image: sigp/lighthouse:v8.2.0
         container_name: consensus
         restart: always
         command:

--- a/blueprints/ethereum/package.json
+++ b/blueprints/ethereum/package.json
@@ -17,7 +17,7 @@
         "name": "geth-1.17.4-lighthouse-8.2.0-full.yml"
       },
       {
-        "name": "reth-1.10.2-lighthouse-8.1.3-archive.yml"
+        "name": "reth-2.3.0-lighthouse-8.2.0-archive.yml"
       },
       {
         "name": "erigon-3.5.0-caplin-archive.yml"

--- a/blueprints/ethereum/samples/.env-mainnet-reth-lighthouse-archive
+++ b/blueprints/ethereum/samples/.env-mainnet-reth-lighthouse-archive
@@ -16,7 +16,7 @@ AWS_REGION="us-east-1"
 BLOCKCHAIN_PROTOCOL="ethereum"
 DEPLOYMENT_MODE="single-node"
 BC_NETWORK="mainnet"
-CLIENT_CONFIG="reth-1.10.2-lighthouse-8.1.3-archive.yml"
+CLIENT_CONFIG="reth-2.3.0-lighthouse-8.2.0-archive.yml"
 
 # Instance Configuration - HIGH PERFORMANCE
 # Graviton4 with NVMe instance store for maximum I/O


### PR DESCRIPTION
Upgrade the Reth archive configuration from Reth 1.10.2 to 2.3.0 and Lighthouse 8.1.3 to 8.2.0 (reth-2.3.0-lighthouse-8.2.0-archive.yml).

Reth 2.x is a major release. Reviewed release notes v2.0.0-v2.3.0:
- No node-operator CLI flags were renamed or removed; the config's flags (--chain, --authrpc.*, --datadir, --http*, --ws*, --log.file.max-files) are unchanged. The 2.0 breaking changes are internal Rust crate/API only.
- Storage V2 is the default in 2.x. A fresh node syncs on V2 automatically, matching the blueprint's replace-the-instance upgrade model.
- Discv5 discovery is enabled by default from 2.2; the config uses discovery defaults, so it simply adopts the new default.

Updates the config file name, image tags (ghcr.io/paradigmxyz/reth:v2.3.0, sigp/lighthouse:v8.2.0), package.json availableConfigurations, and the sample .env CLIENT_CONFIG. Validated with npm run build, npm run test (473 passing), and npx cdk synth (dummy protocol).

This is the second of a two-stage client version update; stage 1 (routine and security bumps for the other clients) is a separate PR.

BREAKING CHANGE: existing Reth v1 archive nodes cannot upgrade in place because Reth 2.x defaults to Storage V2. Operators must deploy a new node and resync (or run `reth db migrate-v2`).

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [x] I have run `npm run build` successfully
- [x] I have run `npm run test` and all tests pass
- [x] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [x] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
