### PR TITLE
fix(ethereum): replace dead beaconstate.info checkpoint endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - **BNB Chain**: BSC Reth `v0.0.10-beta` → `v0.1.0-fix`.
 - **Bitcoin**: Bitcoin Core `v31.0` → `v31.1`.
 
+### Fixed
+
+- **Ethereum**: replaced the `beaconstate.info` checkpoint-sync endpoints, which no longer resolve, across the README, sample `.env` files, and the blueprint's default (`package.json`). Mainnet now defaults to `https://beaconstate.ethstaker.cc` and Sepolia to `https://checkpoint-sync.sepolia.ethpandaops.io`. Without this, consensus clients crash-loop on startup ("Failed to start beacon node") because they cannot reach the checkpoint endpoint.
+
 ## [2.0.0] — 2026-06-22
 
 ### Breaking Changes

--- a/blueprints/ethereum/README.md
+++ b/blueprints/ethereum/README.md
@@ -253,16 +253,16 @@ Checkpoint sync dramatically reduces initial sync time (from days to hours):
 
 ```bash
 # Mainnet
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.ethstaker.cc"
 
 # Sepolia
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://sepolia.beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://checkpoint-sync.sepolia.ethpandaops.io"
 
 # Holesky
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://holesky.beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://checkpoint-sync.holesky.ethpandaops.io"
 ```
 
-More checkpoint sync endpoints: https://eth-clients.github.io/checkpoint-sync-endpoints/
+Pick any provider from the maintained list — https://eth-clients.github.io/checkpoint-sync-endpoints/ — if one is unreachable. Endpoints do come and go (the previously used `beaconstate.info` domain stopped resolving).
 
 ### Supernode Mode (Lighthouse — PeerDAS)
 

--- a/blueprints/ethereum/package.json
+++ b/blueprints/ethereum/package.json
@@ -115,7 +115,7 @@
     },
     "customEnvVarsNamePrefix": "ETH",
     "customEnvVars": [
-      "ETH_CONSENSUS_CHECKPOINT_SYNC_URL=https://beaconstate.info",
+      "ETH_CONSENSUS_CHECKPOINT_SYNC_URL=https://beaconstate.ethstaker.cc",
       "ETH_CONSENSUS_SUPERNODE=true"
     ]
   }

--- a/blueprints/ethereum/samples/.env-mainnet-besu-teku-full
+++ b/blueprints/ethereum/samples/.env-mainnet-besu-teku-full
@@ -37,4 +37,4 @@ DATA_VOL_1_FILESYSTEM="ext4"
 SNAPSHOT_ENABLED="false"
 
 # Ethereum Custom Configuration
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.ethstaker.cc"

--- a/blueprints/ethereum/samples/.env-mainnet-erigon-caplin-archive
+++ b/blueprints/ethereum/samples/.env-mainnet-erigon-caplin-archive
@@ -37,4 +37,4 @@ SNAPSHOT_ENABLED="false"
 
 # Ethereum Custom Configuration
 # Caplin uses checkpoint sync for fast consensus layer sync
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.ethstaker.cc"

--- a/blueprints/ethereum/samples/.env-mainnet-erigon-prysm-archive
+++ b/blueprints/ethereum/samples/.env-mainnet-erigon-prysm-archive
@@ -35,4 +35,4 @@ DATA_VOL_1_FILESYSTEM="ext4"
 SNAPSHOT_ENABLED="false"
 
 # Ethereum Custom Configuration
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.ethstaker.cc"

--- a/blueprints/ethereum/samples/.env-mainnet-geth-lighthouse-full
+++ b/blueprints/ethereum/samples/.env-mainnet-geth-lighthouse-full
@@ -39,7 +39,7 @@ SNAPSHOT_ENABLED="false"
 
 # Ethereum Custom Configuration
 # More checkpoint sync options: https://eth-clients.github.io/checkpoint-sync-endpoints/
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.ethstaker.cc"
 
 # Supernode mode (Lighthouse only) - stores all 128 data columns for full blob serving.
 # Required post-Pectra (May 2025) for blob_sidecars API and L2 rollup derivation.

--- a/blueprints/ethereum/samples/.env-mainnet-geth-lighthouse-full-ha
+++ b/blueprints/ethereum/samples/.env-mainnet-geth-lighthouse-full-ha
@@ -50,7 +50,7 @@ HA_NODES_HEARTBEAT_DELAY_MIN="60"
 HA_ALB_DEREGISTRATION_DELAY_SEC="30"
 
 # Ethereum Custom Configuration
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.ethstaker.cc"
 
 # Supernode mode (Lighthouse only) - stores all 128 data columns for full blob serving.
 # Required post-Pectra (May 2025) for blob_sidecars API and L2 rollup derivation.

--- a/blueprints/ethereum/samples/.env-mainnet-reth-lighthouse-archive
+++ b/blueprints/ethereum/samples/.env-mainnet-reth-lighthouse-archive
@@ -35,7 +35,7 @@ DATA_VOL_1_FILESYSTEM="ext4"
 SNAPSHOT_ENABLED="false"
 
 # Ethereum Custom Configuration
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://beaconstate.ethstaker.cc"
 
 # Supernode mode (Lighthouse only) - stores all 128 data columns for full blob serving.
 # Required post-Pectra (May 2025) for blob_sidecars API and L2 rollup derivation.

--- a/blueprints/ethereum/samples/.env-sepolia-geth-lighthouse-full
+++ b/blueprints/ethereum/samples/.env-sepolia-geth-lighthouse-full
@@ -38,7 +38,7 @@ DATA_VOL_1_FILESYSTEM="ext4"
 SNAPSHOT_ENABLED="false"
 
 # Ethereum Custom Configuration
-ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://sepolia.beaconstate.info"
+ETH_CONSENSUS_CHECKPOINT_SYNC_URL="https://checkpoint-sync.sepolia.ethpandaops.io"
 
 # Supernode mode (Lighthouse only) - stores all 128 data columns for full blob serving.
 # Required post-Pectra (May 2025) for blob_sidecars API and L2 rollup derivation.

--- a/test/integration/ethereum-configuration.test.ts
+++ b/test/integration/ethereum-configuration.test.ts
@@ -56,7 +56,7 @@ describe('Ethereum Protocol Configuration', () => {
             const protocolConfig = configLoader.loadProtocolConfig('ethereum');
 
             expect(protocolConfig.customEnvVarsNamePrefix).toBe('ETH');
-            expect(protocolConfig.customEnvVars).toContain('ETH_CONSENSUS_CHECKPOINT_SYNC_URL=https://beaconstate.info');
+            expect(protocolConfig.customEnvVars).toContain('ETH_CONSENSUS_CHECKPOINT_SYNC_URL=https://beaconstate.ethstaker.cc');
         });
 
         it('should have monitoring configuration for dual clients', () => {
@@ -86,7 +86,7 @@ describe('Ethereum Protocol Configuration', () => {
             const envConfig = configLoader.loadEnvironmentConfig(envPath);
 
             expect(envConfig.CUSTOM_VARIABLES).toBeDefined();
-            expect(envConfig.CUSTOM_VARIABLES.ETH_CONSENSUS_CHECKPOINT_SYNC_URL).toBe('https://beaconstate.info');
+            expect(envConfig.CUSTOM_VARIABLES.ETH_CONSENSUS_CHECKPOINT_SYNC_URL).toBe('https://beaconstate.ethstaker.cc');
         });
     });
 


### PR DESCRIPTION
The beaconstate.info checkpoint-sync domain no longer resolves (verified from two independent networks), so consensus clients configured with it crash-loop on startup with "Failed to start beacon node: Error loading checkpoint state from remote ... client error (Connect)". This surfaced during a Reth archive node smoke test on Sepolia.

Replace the endpoints across the Ethereum blueprint with currently-working providers from the maintained eth-clients list:
- Mainnet: https://beaconstate.info -> https://beaconstate.ethstaker.cc
- Sepolia: https://sepolia.beaconstate.info -> https://checkpoint-sync.sepolia.ethpandaops.io
- Holesky (README only): https://holesky.beaconstate.info -> https://checkpoint-sync.holesky.ethpandaops.io

Updated: blueprints/ethereum/README.md, the blueprint default in package.json (customEnvVars), all mainnet sample .env files, the sepolia sample, and the matching integration-test expectations. Also note in the README that endpoints change over time and link the maintained list.

Verified the chosen mainnet and sepolia endpoints return HTTP 200. Validated with npm run build, npm run test (473 passing), npx cdk synth.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [x] I have updated relevant documentation (if applicable)
- [x] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
