### PR TITLE
chore(ethereum): bump Nethermind, Erigon, Prysm patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- **Ethereum**: bumped patch versions — Nethermind `1.39.2` → `1.39.3`, Erigon `3.5.3` → `3.5.4`, and Prysm `7.1.7` → `7.1.8`. All three are drop-in upgrades within the same release series with no blueprint CLI flag changes; configuration file names and matching `samples/` were updated accordingly.
 - **Ethereum**: bumped client versions — Geth `1.17.3` → `1.17.4`, Erigon `3.4.3` → `3.5.3`, Prysm `7.1.5` → `7.1.7`, and Besu `26.6.1` → `26.7.0`. Configuration file names and matching `samples/` were updated accordingly. (Nethermind and Teku are covered under Security above.)
 - **Ethereum**: upgraded the Reth archive configuration to Reth `1.10.2` → `2.4.1` and Lighthouse `8.1.3` → `8.2.1` (`reth-2.4.1-lighthouse-8.2.1-archive.yml`). Reth 2.x makes **Storage V2** the default; there is no in-place upgrade for an existing Reth v1 datadir, so upgrading requires deploying a new node and resyncing (consistent with the blueprint's replace-the-instance upgrade model). Reth 2.2 also enables Discv5 discovery by default. No blueprint CLI flags changed.
 - **Solana**: Agave `4.1.0-rc.1` → `4.1.2` (prerelease replaced with the stable `4.1.x` line); Frankendancer `0.912.40003` → `0.1006.40100`. The Agave `3.1.14` and `4.0.3` (default) configurations are already current and unchanged.

--- a/blueprints/ethereum/configurations/erigon-3.5.4-caplin-archive.yml
+++ b/blueprints/ethereum/configurations/erigon-3.5.4-caplin-archive.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
     execution:
-        image: erigontech/erigon:v3.5.3
+        image: erigontech/erigon:v3.5.4
         container_name: execution
         restart: always
         user: "1002:1002"

--- a/blueprints/ethereum/configurations/erigon-3.5.4-prysm-7.1.8-archive.yml
+++ b/blueprints/ethereum/configurations/erigon-3.5.4-prysm-7.1.8-archive.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
     execution:
-        image: erigontech/erigon:v3.5.3
+        image: erigontech/erigon:v3.5.4
         container_name: execution
         restart: always
         user: "1002:1002"
@@ -34,7 +34,7 @@ services:
         network_mode: host
 
     consensus:
-        image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.7
+        image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.8
         container_name: consensus
         restart: always
         user: "1002:1002"

--- a/blueprints/ethereum/configurations/nethermind-1.39.3-teku-26.7.1-full.yml
+++ b/blueprints/ethereum/configurations/nethermind-1.39.3-teku-26.7.1-full.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
     execution:
-        image: nethermind/nethermind:1.39.2
+        image: nethermind/nethermind:1.39.3
         container_name: execution
         restart: always
         command:

--- a/blueprints/ethereum/package.json
+++ b/blueprints/ethereum/package.json
@@ -20,16 +20,16 @@
         "name": "reth-2.4.1-lighthouse-8.2.1-archive.yml"
       },
       {
-        "name": "erigon-3.5.3-caplin-archive.yml"
+        "name": "erigon-3.5.4-caplin-archive.yml"
       },
       {
-        "name": "erigon-3.5.3-prysm-7.1.7-archive.yml"
+        "name": "erigon-3.5.4-prysm-7.1.8-archive.yml"
       },
       {
         "name": "besu-26.7.0-teku-26.7.1-full.yml"
       },
       {
-        "name": "nethermind-1.39.2-teku-26.7.1-full.yml"
+        "name": "nethermind-1.39.3-teku-26.7.1-full.yml"
       }
     ],
     "BC_NETWORKS": [

--- a/blueprints/ethereum/samples/.env-mainnet-erigon-caplin-archive
+++ b/blueprints/ethereum/samples/.env-mainnet-erigon-caplin-archive
@@ -17,7 +17,7 @@ AWS_REGION="us-east-1"
 BLOCKCHAIN_PROTOCOL="ethereum"
 DEPLOYMENT_MODE="single-node"
 BC_NETWORK="mainnet"
-CLIENT_CONFIG="erigon-3.5.3-caplin-archive.yml"
+CLIENT_CONFIG="erigon-3.5.4-caplin-archive.yml"
 
 # Instance Configuration - HIGH PERFORMANCE
 # Graviton4 with NVMe instance store for maximum I/O

--- a/blueprints/ethereum/samples/.env-mainnet-erigon-prysm-archive
+++ b/blueprints/ethereum/samples/.env-mainnet-erigon-prysm-archive
@@ -16,7 +16,7 @@ AWS_REGION="us-east-1"
 BLOCKCHAIN_PROTOCOL="ethereum"
 DEPLOYMENT_MODE="single-node"
 BC_NETWORK="mainnet"
-CLIENT_CONFIG="erigon-3.5.3-prysm-7.1.7-archive.yml"
+CLIENT_CONFIG="erigon-3.5.4-prysm-7.1.8-archive.yml"
 
 # Instance Configuration - HIGH PERFORMANCE
 # Graviton4 with NVMe instance store for maximum I/O


### PR DESCRIPTION
Drop-in, same-series patch bumps that require no smoke test (no blueprint CLI flag changes):

- Nethermind 1.39.2 -> 1.39.3 (upstream mandatory reliability update)
- Erigon    3.5.3  -> 3.5.4  (RPC gzip native memory-leak fix)
- Prysm      7.1.7  -> 7.1.8  (patch)

Rename the version-pinned config files and update the matching package.json availableConfigurations entries and samples/.env CLIENT_CONFIG references. Build (tsc) and jest (473 tests) pass.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction — we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-samples/aws-blockchain-node-runners/blob/main/CONTRIBUTING.md) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New blueprint (adding a new protocol — see checklist below)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

- [ ] I have run `npm run build` successfully
- [ ] I have run `npm run test` and all tests pass
- [ ] I have run `npx cdk synth` with a sample `.env` (e.g. from `blueprints/dummy/samples/`) and it succeeds
- [ ] I have run pre-commit hooks: `npm run run-pre-commit`

### New Blueprint Checklist (if adding a protocol)

- [ ] Blueprint follows the structure of `blueprints/dummy/` (reference implementation)
- [ ] Blueprint README follows the standard template (matches Dummy section titles and ordering)
- [ ] Setup section points to [Getting Started](https://aws-samples.github.io/aws-blockchain-node-runners/docs/getting-started/quickstart) (not inline instructions)
- [ ] Deployment section leads with AI-driven deployment (Option 1) and manual as Option 2
- [ ] Sample `.env` files are provided for at least one network (mainnet or testnet)
- [ ] Configuration scripts follow the install/run dispatch pattern (see `blueprints/dummy/`)
- [ ] Blueprint page added to `website/docs/blueprints/` (.mdx mirror importing README)
- [ ] Client Release Channels table added to README under Additional Resources

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have run `cd website && npm run build` with no broken links (if docs changed)

### License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
